### PR TITLE
C++ Region Manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ message(STATUS "Z3_FOUND: ${Z3_FOUND}")
 message(STATUS "Found Z3 ${Z3_VERSION_STRING}")
 message(STATUS "Z3_DIR: ${Z3_DIR}")
 
-add_executable(BombeBruteForce main.cpp)
+add_executable(BombeBruteForce main.cpp RegionTypes/RegionType.cpp RegionTypes/RegionType.h
+        RegionTypes/EqualsRegionType.cpp RegionTypes/EqualsRegionType.h)
 # Taken from the Z3 C++ Example Project
 target_include_directories(BombeBruteForce PRIVATE ${Z3_CXX_INCLUDE_DIRS})
 target_link_libraries(BombeBruteForce PRIVATE ${Z3_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ message(STATUS "Found Z3 ${Z3_VERSION_STRING}")
 message(STATUS "Z3_DIR: ${Z3_DIR}")
 
 add_executable(BombeBruteForce main.cpp RegionTypes/RegionType.cpp RegionTypes/RegionType.h
-        RegionTypes/EqualsRegionType.cpp RegionTypes/EqualsRegionType.h)
+        RegionTypes/EqualsRegionType.cpp RegionTypes/EqualsRegionType.h RegionManager.cpp RegionManager.h)
 # Taken from the Z3 C++ Example Project
 target_include_directories(BombeBruteForce PRIVATE ${Z3_CXX_INCLUDE_DIRS})
 target_link_libraries(BombeBruteForce PRIVATE ${Z3_LIBRARIES})

--- a/RegionManager.cpp
+++ b/RegionManager.cpp
@@ -1,0 +1,160 @@
+//
+// Created on 4/8/2023.
+//
+
+#include <sstream>
+#include <iostream>
+#include "RegionManager.h"
+
+using namespace z3;
+
+RegionManager::RegionManager(RegionType** regionTypes, size_t numRegions) :
+    solver(ctx), size(numRegions), numCells(1 << size) {
+    // SECT [n] referrs to things in testZ3.py and RegionHandler.py
+    // note that those are .py so they're in the py_code folder
+
+    // SECT 0 initializes ctx (automatically done) and solver (in the member initializer list)
+
+    // SECT 1 initializes regionTypes
+    // Size is auto-declared in the member initializer list
+    // So we need to initialize regionTypes
+    // First initialize the region-array
+    regions = new expr*[size];
+    // Then initialize each element of the region-array:
+    for(size_t i = 0; i < size; i++){
+        char* name = new char[2] {static_cast<char>('A'+i), '\0'};
+        auto region = new expr(ctx.int_const(name));
+        delete[] name;
+        regions[i] = region;
+    }
+
+    // SECT 2 initializes cells
+    // I decided to split SECT 2 and SECT 3 because it makes the code somewhat better
+    // Initialize the array of cells:
+    cells = new expr*[numCells];
+    // and make sure the zero cell is null:
+    cells[0] = nullptr;
+    // Initialize each cell:
+    for(size_t i = 1; i < numCells; i++){
+        // Initialize the actual cell variable:
+        std::stringstream cellName;
+        size_t bits = i;
+        char regionName = 'a';
+        while(bits > 0){
+            if(bits%2 == 1){
+                cellName << regionName;
+            }
+            regionName++;
+            bits >>= 1;
+        }
+
+        // It's probably faster to just use a c-string to begin with
+        // so I don't feel like writing that out until it's actually a significant # of clock cycles
+        auto cell = new expr(ctx.int_const(cellName.str().c_str()));
+        // Save the cell
+        cells[i] = cell;
+
+        // Update the solver with the cell min and maxes. Cell maxes are provided because one of the solver tactics
+        // requires a min and a max, so maybe having both will make the solver run slightly faster?
+        // And mins are provided because of course we can't have negative mines in a cell
+        solver.add(*cell >= 0);
+        solver.add(*cell <= 99);
+    }
+
+    // SECT 3 initializes the region sums
+    // More specifically, it declares that region A is cells a + ab + ac + abc
+    // Initialize regionSums as a copy of region:
+    auto** regionSums = new expr*[size];
+    for(size_t i = 0; i < size; i++){
+        regionSums[i] = new expr(*regions[i]);
+    }
+    // Make sure the regionSums have their cells set correctly:
+    for(size_t i = 1; i < numCells; i++){
+        size_t bits = i;
+        size_t regionNum = 0;
+        auto cell = *cells[i];
+        while(bits > 0){
+            if(bits%2 == 1){
+                expr region = *regionSums[regionNum];
+                std::cout << region << std::endl;
+                std::cout << cell << std::endl;
+                region = region - cell;
+                regionSums[regionNum][0] = region;
+            }
+            bits >>= 1;
+            regionNum++;
+        }
+    }
+    // and tell the solver that the regionSums are all zero
+    // aka that region - cell - cell - cell = 0
+    // aka that region = cell + cell + cell
+    for(size_t i = 0; i < size; i++){
+        auto sum = *regionSums[i];
+        solver.add(sum == 0);
+    }
+    // clean up the memory
+    for(size_t i = 0; i < size; i++){
+        delete regionSums[i];
+    }
+    delete[] regionSums;
+
+    // SECT 4
+    // Getting the data from the RegionType parameter
+    for(size_t i = 0; i < size; i++){
+        RegionType* regionType = regionTypes[i];
+        expr regionVar = *regions[i];
+        expr regionExpr = regionType->getExpr(regionVar);
+        solver.add(regionExpr);
+        // A small optimization.
+        solver.add(regionVar <= regionType->getMaxMines());
+    }
+}
+
+RegionManager::~RegionManager() {
+    // TODO: Valgrind this to check if this properly deletes everything.
+    for(size_t i = 0; i < size; i++){
+        delete regions[i];
+    }
+    delete[] regions;
+
+    for(size_t i = 1; i < numCells; i++){
+        delete cells[i];
+    }
+    delete[] cells;
+}
+
+void RegionManager::test(int *cellLimits) {
+    solver.push();
+    for(size_t i = 1; i < numCells; i++){
+        auto cell = *cells[i];
+        solver.add(cell <= cellLimits[i]);
+    }
+    std::cout << "Solver state:\n";
+    std::cout << solver << "\n";
+    std::cout << "SMT2 solver state:\n";
+    std::cout << solver.to_smt2() << "\n";
+    if(solver.check() == unsat){
+        std::cout << "Test output is UNSAT\n";
+    }
+    for(size_t cellNum = 1; cellNum < numCells; cellNum++){
+        std::vector<int> vals;
+        auto cell = *cells[cellNum];
+        for(int numMines = 0; numMines < 11; numMines++){
+            auto assumption = cell == numMines;
+            auto result = solver.check(1, &assumption);
+            // If result is UNSAT then it is not possible for cell to have numMines mines
+            // If result is NOT UNSAT then it is NOT (not possible for cell to have numMines mines)
+            // If result is NOT UNSAT then it is possible for cell to have numMines mines
+            if(result != unsat){
+                vals.push_back(numMines);
+            }
+        }
+        std::cout << "Possible mine values for cell " << cell << ": [";
+        for(int i : vals){
+            std::cout << i << ", ";
+        }
+        std::cout << "]" << std::endl;
+    }
+
+    solver.pop();
+}

--- a/RegionManager.h
+++ b/RegionManager.h
@@ -1,0 +1,36 @@
+//
+// Created on 4/8/2023.
+//
+
+#ifndef BOMBEBRUTEFORCE_REGIONMANAGER_H
+#define BOMBEBRUTEFORCE_REGIONMANAGER_H
+
+
+#include "RegionTypes/RegionType.h"
+
+class RegionManager {
+public:
+    RegionManager(RegionType** regionTypes, size_t numRegions);
+
+    ~RegionManager();
+    RegionManager operator=(const RegionManager& oth) = delete;
+    RegionManager(RegionManager& oth) = delete;
+
+    // Returns "void" for now so I can just print the output and see what I get
+    // but in the future I'll need to port the Deduction class.
+    void test(int* cellLimits);
+private:
+    z3::context ctx;
+    z3::solver solver;
+    z3::expr** regions;
+    size_t size;
+    z3::expr** cells;
+    /**
+     * Note: numCells is actually the number of cells +1.
+     * This is because index 0 would be represented by the cell not covered by ANY region
+     */
+    size_t numCells;
+};
+
+
+#endif //BOMBEBRUTEFORCE_REGIONMANAGER_H

--- a/RegionTypes/EqualsRegionType.cpp
+++ b/RegionTypes/EqualsRegionType.cpp
@@ -1,0 +1,33 @@
+//
+// Created by cppac on 4/8/2023.
+//
+
+#include "EqualsRegionType.h"
+
+// I didn't like having this in the header file even if it's an empty code block.
+EqualsRegionType::EqualsRegionType(int validCount) : EqualsRegionType(&validCount, 1) {
+
+}
+
+EqualsRegionType::EqualsRegionType(const int *validCounts, size_t arrSize) : countSize(arrSize){
+    if(countSize == 0){
+        throw std::invalid_argument("EqualsRegionType needs to be equal to at least one number.");
+    }
+    this->validCounts = new int[arrSize];
+    for(size_t i = 0; i < countSize; i++){
+        this->validCounts[i] = validCounts[i];
+    }
+}
+
+EqualsRegionType::~EqualsRegionType() {
+    delete[] validCounts;
+}
+
+z3::expr EqualsRegionType::getExpr(const z3::expr& var) {
+    // Constructor guarantees that countSize will always be nonzero
+    z3::expr out = (var == this->validCounts[0]);
+    for(size_t i = 1; i < countSize; i++){
+        out = out || (var == this->validCounts[i]);
+    }
+    return out;
+}

--- a/RegionTypes/EqualsRegionType.cpp
+++ b/RegionTypes/EqualsRegionType.cpp
@@ -1,5 +1,5 @@
 //
-// Created by cppac on 4/8/2023.
+// Created on 4/8/2023.
 //
 
 #include "EqualsRegionType.h"

--- a/RegionTypes/EqualsRegionType.h
+++ b/RegionTypes/EqualsRegionType.h
@@ -1,0 +1,39 @@
+//
+// Created by cppac on 4/8/2023.
+//
+
+#ifndef BOMBEBRUTEFORCE_EQUALSREGIONTYPE_H
+#define BOMBEBRUTEFORCE_EQUALSREGIONTYPE_H
+
+
+#include "RegionType.h"
+
+class EqualsRegionType : RegionType{
+public:
+    /**
+     * Same as EqualsRegionType(&validCount, 1)
+     * Used for if exactly 1 mine is in the region, or exactly 2 mines, or whatever
+     * @param validCount The number of mines this region has
+     */
+    explicit EqualsRegionType(int validCount);
+    /**
+     * Sets this region to have a number of mines exactly equal to one of the values in validCounts.
+     * So if validCounts is [1, 3, 5], then the getExpr of this region will return that this has either exactly 1 mine,
+     * exactly 3 mines, or exactly 5 mines, but no other value.
+     * @param validCounts The numbers of valid mines.
+     * @param arrSize The size of the validCounts array.
+     */
+    EqualsRegionType(const int validCounts[], size_t arrSize);
+    ~EqualsRegionType();
+
+    EqualsRegionType operator=(const EqualsRegionType& oth) = delete;
+    EqualsRegionType(EqualsRegionType& oth) = delete;
+
+    z3::expr getExpr(const z3::expr& var) override;
+private:
+    int* validCounts{}; // Can't be 0 or null terminated since it's possible this could be fed a 0/2 region
+    size_t countSize{};
+};
+
+
+#endif //BOMBEBRUTEFORCE_EQUALSREGIONTYPE_H

--- a/RegionTypes/EqualsRegionType.h
+++ b/RegionTypes/EqualsRegionType.h
@@ -1,5 +1,5 @@
 //
-// Created by cppac on 4/8/2023.
+// Created on 4/8/2023.
 //
 
 #ifndef BOMBEBRUTEFORCE_EQUALSREGIONTYPE_H
@@ -8,7 +8,7 @@
 
 #include "RegionType.h"
 
-class EqualsRegionType : RegionType{
+class EqualsRegionType : public RegionType{
 public:
     /**
      * Same as EqualsRegionType(&validCount, 1)
@@ -24,8 +24,8 @@ public:
      * @param arrSize The size of the validCounts array.
      */
     EqualsRegionType(const int validCounts[], size_t arrSize);
-    ~EqualsRegionType();
 
+    ~EqualsRegionType();
     EqualsRegionType operator=(const EqualsRegionType& oth) = delete;
     EqualsRegionType(EqualsRegionType& oth) = delete;
 

--- a/RegionTypes/RegionType.cpp
+++ b/RegionTypes/RegionType.cpp
@@ -1,0 +1,9 @@
+//
+// Created on 4/8/2023.
+//
+
+#include "RegionType.h"
+
+int RegionType::getMaxMines() {
+    return 99;
+}

--- a/RegionTypes/RegionType.h
+++ b/RegionTypes/RegionType.h
@@ -23,6 +23,8 @@ public:
      * Used for certain optimizations, but as a side-effect will never let a region have more than 99 mines.
      */
     virtual int getMaxMines();
+
+    virtual ~RegionType(){};
 };
 
 

--- a/RegionTypes/RegionType.h
+++ b/RegionTypes/RegionType.h
@@ -1,0 +1,29 @@
+//
+// Created on 4/8/2023.
+//
+
+#ifndef BOMBEBRUTEFORCE_REGIONTYPE_H
+#define BOMBEBRUTEFORCE_REGIONTYPE_H
+
+
+#include <string>
+#include <z3++.h>
+
+class RegionType {
+public:
+    /**
+     * Constructs an expression that matches this region, from the [var].
+     * For example, a 3+ region always has 3 or more mines, so it should return (var >= 3)
+     * @param var The Z3 Expression that names this region
+     * @return An expression that makes the region always true.
+     */
+    virtual z3::expr getExpr(const z3::expr& var) = 0;
+    /**
+     * Returns the maximum # of mines that can be in this Region.
+     * Used for certain optimizations, but as a side-effect will never let a region have more than 99 mines.
+     */
+    virtual int getMaxMines();
+};
+
+
+#endif //BOMBEBRUTEFORCE_REGIONTYPE_H

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,9 @@
 #include <sstream>
 #include<vector>
 #include"z3++.h"
+#include "RegionTypes/RegionType.h"
+#include "RegionTypes/EqualsRegionType.h"
+#include "RegionManager.h"
 
 using namespace z3;
 
@@ -36,7 +39,23 @@ void demorgan() {
 int main() {
     std::cout << "Hello, World!" << std::endl;
 
-    demorgan();
+    // demorgan();
+
+    auto types = new RegionType*[3];
+    types[0] = new EqualsRegionType(1);
+    types[1] = new EqualsRegionType(1);
+    types[2] = new EqualsRegionType(2);
+
+    RegionManager manager(types, 3);
+
+    int* limits = new int[8] {0, 11, 11, 11, 0, 11, 11, 11};
+    manager.test(limits);
+    delete[] limits;
+
+    for(size_t i = 0; i < 3; i++){
+        delete types[i];
+    }
+    delete[] types;
 
     return 0;
 }


### PR DESCRIPTION
Now that RegionManager (and its test() function) has been ported, theoretically we don't need to write any more functions in RegionManager - we could just keep calling test().

That is a very, very slow process, so I do plan to add more functions to RegionManager. However, that much progress is enough for me to think "yeah we can merge that into main".

As always, the 3-region combination of (=1, =1, =2) is provided. (Since the Deduction class has not been ported, it simply outputs its deductions to cout and test returns void)