### PR TITLE
Have DeductionManager know its super-deduction.

### DIFF
--- a/Deductions/Deduction.cpp
+++ b/Deductions/Deduction.cpp
@@ -157,11 +157,11 @@ void Deduction::setCellData(size_t cellNum, uint64_t data) {
 }
 
 Deduction operator&&(const Deduction &lhs, const Deduction &rhs) {
-    if(lhs.numCells != rhs.numCells){
-        return Deduction(lhs.numCells, false); // can't combine, all-false
+    if(lhs.getNumCells() != rhs.getNumCells()){
+        return {lhs.getNumCells(), false}; // can't combine, all-false
     }
     Deduction out(lhs);
-    for(int i = 1; i < lhs.numCells; i++){
+    for(int i = 1; i < lhs.getNumCells(); i++){
         out.setCellData(i, out.getCellData(i) & rhs.getCellData(i));
     }
     return out;

--- a/Deductions/Deduction.cpp
+++ b/Deductions/Deduction.cpp
@@ -151,3 +151,18 @@ int Deduction::getMaxMinesInCell(size_t cellNum) const {
 uint64_t Deduction::getCellData(size_t cellNum) const {
     return cellStates[cellNum];
 }
+
+void Deduction::setCellData(size_t cellNum, uint64_t data) {
+    cellStates[cellNum] = data;
+}
+
+Deduction operator&&(const Deduction &lhs, const Deduction &rhs) {
+    if(lhs.numCells != rhs.numCells){
+        return Deduction(lhs.numCells, false); // can't combine, all-false
+    }
+    Deduction out(lhs);
+    for(int i = 1; i < lhs.numCells; i++){
+        out.setCellData(i, out.getCellData(i) & rhs.getCellData(i));
+    }
+    return out;
+}

--- a/Deductions/Deduction.h
+++ b/Deductions/Deduction.h
@@ -67,6 +67,7 @@ public:
     int getMaxMinesInCell(size_t cellNum) const;
 
     uint64_t getCellData(size_t cellNum) const;
+    void setCellData(size_t cellNum, uint64_t data);
 private:
     // Whether Cell C has N mines is a bool
     // So each item of N mines in each cell C is a bool
@@ -80,5 +81,7 @@ private:
     uint64_t* cellStates;
     size_t numCells;
 };
+
+Deduction operator&&(const Deduction& lhs, const Deduction& rhs);
 
 #endif //BOMBEBRUTEFORCE_DEDUCTION_H

--- a/Deductions/DeductionManager.cpp
+++ b/Deductions/DeductionManager.cpp
@@ -47,6 +47,8 @@ void DeductionManager::set(int cell, int mines, const Deduction& d) {
 void DeductionManager::set(int cell, int mines, DeductionManager* d){
     // don't even run checks just override the existing DeductionManager.
     children[cell][mines] = d;
+    // if d is the child of this, this is the parent of d.
+    d->parentDM = this;
 }
 
 std::string DeductionManager::toLongStr(const std::string &pre, const Deduction &parent) const { // NOLINT(misc-no-recursion)

--- a/Deductions/DeductionManager.cpp
+++ b/Deductions/DeductionManager.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <sstream>
+#include <iostream>
 
 #include "DeductionManager.h"
 
@@ -48,7 +49,9 @@ void DeductionManager::set(int cell, int mines, DeductionManager* d){
     // don't even run checks just override the existing DeductionManager.
     children[cell][mines] = d;
     // if d is the child of this, this is the parent of d.
-    d->parentDM = this;
+    if(d != nullptr){
+        d->setParent(this);
+    }
 }
 
 std::string DeductionManager::toLongStr(const std::string &pre, const Deduction &parent) const { // NOLINT(misc-no-recursion)
@@ -113,4 +116,12 @@ std::string DeductionManager::toLongStr(const std::string &pre, const Deduction 
 
 std::string DeductionManager::toLongStr() const {
     return toLongStr("", Deduction(numCells, true));
+}
+
+void DeductionManager::setParent(DeductionManager *newParent) {
+    if(parentDM != nullptr){
+        // cerr because this really, really shouldn't happen
+        std::cerr << "WARN: DEDUCTION-MANAGER PARENT IS OVERRIDDEN\n";
+    }
+    parentDM = newParent;
 }

--- a/Deductions/DeductionManager.h
+++ b/Deductions/DeductionManager.h
@@ -19,6 +19,8 @@ public:
     void set(int cell, int mines, const Deduction& d);
     void set(int cell, int mines, DeductionManager* d);
 
+    DeductionManager* get(int cell, int mines) const {return children[cell][mines];};
+
     /**
      * Equivalent to repeated callings of self.toLongStr()
      * With extra notes about "this is cell 1", "this is cell 2",
@@ -30,8 +32,9 @@ public:
     std::string toLongStr() const;
 
     Deduction getDeduction() const {return self;};
-    
+
     DeductionManager* getParent() const { return parentDM;};
+    void setParent(DeductionManager* newParent);
 private:
     /**
      * The deduction that this DeducitonManager knows about.

--- a/Deductions/DeductionManager.h
+++ b/Deductions/DeductionManager.h
@@ -30,6 +30,8 @@ public:
     std::string toLongStr() const;
 
     Deduction getDeduction() const {return self;};
+    
+    DeductionManager* getParent() const { return parentDM;};
 private:
     /**
      * The deduction that this DeducitonManager knows about.
@@ -51,6 +53,12 @@ private:
      * For example, you might want a NULL DeductionManager if its Deduction is NULL.
      */
     DeductionManager*** children;
+
+    // The "parent" of this DeductionManager
+    // If this DeductionManager manages ...XYZ???
+    // then the parent would manage ...XY????
+    // For the all-?'s DeductionManager, there would be no parent so null parent.
+    DeductionManager* parentDM = nullptr;
 };
 
 

--- a/RegionManager.h
+++ b/RegionManager.h
@@ -35,7 +35,7 @@ public:
      * @param index The first index to start manipulating.
      * @param check Only check mine-values which are truthy in this Deduction.
      */
-    DeductionManager* recursive_test(int index, const Deduction& check);
+    DeductionManager* recursive_test(int index, const Deduction& check, DeductionManager* parentDM);
     DeductionManager* recursive_test(int index);
 
     /**

--- a/clockData.txt
+++ b/clockData.txt
@@ -1,31 +1,33 @@
 getClockStr() data:
-getDeduction() time: 2379867
-new DeductionManager time: 210598
-self.isUnsat() time: 41782
-[auto cell = ] time: 4456
-solver.push() time: 420129
-[lastDeduction = self] time: 5946
-cellCompare time: 173630
-solver.add() time: 310270
-[lastDeduction = recursiveOut->getDeduction()] time: 53472
-lastDeduction.isUnsat() time: 40789
-out->set() time: 41930
-solver.pop() time: 85650
+getDeduction() time: 2177187
+new DeductionManager time: 176938
+self.isUnsat() time: 41848
+[auto cell = ] time: 4244
+solver.push() time: 448744
+[lastDeduction = self] time: 5912
+cellCompare time: 177869
+solver.add() time: 317248
+[lastDeduction = recursiveOut->getDeduction()] time: 55755
+lastDeduction.isUnsat() time: 40881
+out->set() time: 42671
+solver.pop() time: 85304
 
-Deduction init time: 50342
-[auto cell] time: 310503
+Deduction init time: 48553
+[auto cell] time: 308723
 [oth] range-finding time: 0
-Calculating which mines to check: 284639
-getDeduction numMines loop time: 282015
-Fast-falsy time: 45172
-Fast-falsy hits: 20740
-No fast-falsy: 2797
-[for model in satModels] loop time: 147025
-[for model in unsatModels] loop time: 45172
+Calculating which mines to check: 282430
+getDeduction numMines loop time: 268619
+Fast-falsy time: 41039
+Fast-falsy hits: 6
+No fast-falsy: 664
+[for model in satModels] loop time: 144488
+[for model in unsatModels] loop time: 41039
 Unsat models caught: 153
 Unsat models known: 3
-[auto assumption] time: 3243
-solver.check() calls: 2797
-solver.check() time: 230385
-getAndSaveModel() time: 1794
-[int* model] processing time: 2
+[auto assumption] time: 963
+solver.check() calls: 664
+solver.check() time: 70789
+getAndSaveModel() time: 1632
+[int* model] processing time: 3
+
+Total time taken: 4023087

--- a/main.cpp
+++ b/main.cpp
@@ -61,8 +61,8 @@ int main() {
     std::ofstream out("../details.txt");
     out << results->toLongStr();
 
+    manager.getClockStr(std::cout);
     std::cout << "Total time taken: " << stopTime - startTime << std::endl;
-    // manager.getClockStr(std::cout);
 
     manager.getModels(std::cout);
 


### PR DESCRIPTION
This lets us make another optimization, and solver.check() calls gets significantly reduced.

Unfortunately, now push and pop are the most time-consuming tasks...